### PR TITLE
docs: add project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,51 @@
+# digitalsoup
+
+DigitalSoup is a marketing website built with [Astro](https://astro.build/), Tailwind CSS, and TypeScript. It provides a modern, responsive starting point for a digital marketing agency.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```
+   or
+   ```bash
+   npm start
+   ```
+
+## Available Scripts
+
+The project defines several npm scripts:
+
+- `npm run dev` &ndash; start the Astro development server with hot reloading.
+- `npm start` &ndash; alias for `npm run dev`.
+- `npm run build` &ndash; type-check and build the site for production in the `dist/` folder.
+- `npm run preview` &ndash; preview the production build locally.
+- `npm run astro` &ndash; run arbitrary [Astro CLI](https://docs.astro.build/en/reference/cli-reference/) commands.
+
+## Deployment
+
+The project uses the `@astrojs/vercel` adapter, making it ready for deployment on [Vercel](https://vercel.com/). Build the site with:
+
+```bash
+npm run build
+```
+
+Deploy the generated `dist/` directory to your preferred hosting provider or connect the repository to Vercel for automatic deployments.
+
+## Contributing
+
+Contributions are welcome! Feel free to open an issue or submit a pull request. Before submitting, ensure the site builds successfully with:
+
+```bash
+npm run build
+```
+
+---
+
+Please keep this README updated as the project evolves.
+


### PR DESCRIPTION
## Summary
- document project purpose and tech stack
- outline setup commands and available npm scripts
- add deployment and contribution notes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b40e34d37083258ea1d3920140c4d2